### PR TITLE
Compat update for POMDPs and POMDPTools to 1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,8 +13,8 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 [compat]
 CommonRLInterface = "0.3.3"
 PDDL = "0.2.1"
-POMDPs = "0.9"
-POMDPTools = "0.1.4"
+POMDPs = "0.9, 1"
+POMDPTools = "0.1.4, 1"
 Random = "<0.0.1, 1"
 julia = "1"
 


### PR DESCRIPTION
Updated the Project.toml for POMDPs and POMDPTools to v1.

I didn't include a version bump with this PR because I was uncertain about how you maintain your versioning. 